### PR TITLE
Split test module into smaller modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
 	"author": "Roy Mor <roy.mor@sisense.com>",
 	"contributors": [
 		"Ray Luxembourg",
-		"Yotam Roth"
+		"Yotam Roth",
+		"Sergei Magera"
 	],
 	"license": "MIT",
 	"description": "GraphQL to REST converter: automatically generate a RESTful API from your existing GraphQL API",

--- a/src/gqlgenerator/index.js
+++ b/src/gqlgenerator/index.js
@@ -45,6 +45,12 @@ const generateGqlQueryFiles = (gqlSchemaObj, destinationDirPath, depthLimitArg =
 		return false;
 	}
 
+	if(!Number.isInteger(depthLimit) || Math.sign(depthLimit) === -1){
+		error('Invalid depthLimitArg parameter. Aborting');
+
+		return false;
+	}
+
 	log(`GQLGenerator initialized with query depthLimit of ${depthLimit}`);
 	try {
 		cleanAndCreateFolder(destDirPath);

--- a/src/graphql2rest.js
+++ b/src/graphql2rest.js
@@ -10,6 +10,7 @@ const dot = require('dot-object');
 const mingo = require('mingo');
 const jmespath = require('jmespath');
 const gql = require('graphql-tag');
+const  {GraphQLSchema} = require('graphql');
 
 const { readDefaultsConfigFile, validateConfig, loadDependencies } = require('./setup');
 const { stripResponseData, defaultFormatErrorFn } = require('./formatters');
@@ -96,7 +97,7 @@ const init = (
 	const { manifest, queryStrings, middlewaresModule } = loadDependencies(config);
 	if (!manifest || !queryStrings) return null;
 
-	if (!schemaObj) {
+	if (!(schemaObj instanceof GraphQLSchema)) {
 		error('init: schema object is required but missing. Aborting initialization.');
 		return null;
 	}

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -1,6 +1,5 @@
 const del = require('del');
 
-const schemaFile = require('./test-fixtures/schemas/basic-graphql-schema-1');
 const GraphQL2REST = require('./../src/index');
 
 const {
@@ -10,15 +9,15 @@ const {
 } = require('./mocks/logger');
 
 
-const clearEnv = (gqlOutputFolder) => {
+const clearEnv = (gqlOutputFolders) => {
 	clearLastConsolePrint();
 	clearBuffer();
-	del.sync(gqlOutputFolder);
+	(gqlOutputFolders || []).forEach(folder => del.sync(folder));
 	loggerMock.supressDebugLevel = false;
 }
 
 const prepareEnv = (schema, gqlOutputFolder) => {
-	clearEnv(gqlOutputFolder);
+	clearEnv([gqlOutputFolder]);
 	GraphQL2REST.generateGqlQueryFiles(schema,
 		gqlOutputFolder, undefined, loggerMock);
 }

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -1,0 +1,38 @@
+const del = require('del');
+
+const schemaFile = require('./test-fixtures/schemas/basic-graphql-schema-1');
+const GraphQL2REST = require('./../src/index');
+
+const {
+	loggerMock,
+	clearBuffer,
+	clearLastConsolePrint,
+} = require('./mocks/logger');
+
+
+const clearEnv = (gqlOutputFolder) => {
+	clearLastConsolePrint();
+	clearBuffer();
+	del.sync(gqlOutputFolder);
+	loggerMock.supressDebugLevel = false;
+}
+
+const prepareEnv = (schema, gqlOutputFolder) => {
+	clearEnv(gqlOutputFolder);
+	GraphQL2REST.generateGqlQueryFiles(schema,
+		gqlOutputFolder, undefined, loggerMock);
+}
+
+const getOptions = (gqlOutputFolder) => ({
+	logger: loggerMock,
+	gqlGeneratorOutputFolder: gqlOutputFolder,
+	manifestFile: '../test/test-fixtures/manifests/basicManifest1.json',
+	apiPrefix: '/testApp/v1',
+	middlewaresFile: '../test/test-fixtures/middleware/request-middleware.js'
+});
+
+const noop = () =>{};
+
+module.exports = { noop, prepareEnv, clearEnv, getOptions };
+
+

--- a/test/unit/generateGqlQueryFiles.test.js
+++ b/test/unit/generateGqlQueryFiles.test.js
@@ -1,0 +1,149 @@
+const path = require('path');
+const {	test } = require('mocha');
+const chai = require('chai');
+const chaifs = require('chai-fs');
+const { expect } = chai;
+const {	buildSchema } = require('graphql');
+const del = require('del');
+
+const schemaFile = require('../test-fixtures/schemas/basic-graphql-schema-1');
+const schemaFileAdvanced = require('../test-fixtures/schemas/advanced-graphql-schema');
+const GraphQL2REST = require('../../src/index');
+const {
+	loggerMock,
+	clearBuffer,
+	clearLastConsolePrint,
+} = require('../mocks/logger');
+const GQL_OUTPUT_FOLDER = path.resolve(__dirname, '../test-outputs/gqloutput');
+const GQL_OUTPUT_FOLDER_ADVANCED_TESTS = path.resolve(__dirname, '../test-outputs/gqloutput_advanced');
+
+chai.use(chaifs);
+
+describe('generateGqlQueryFiles:', () => {
+
+	const schema = buildSchema(schemaFile.schema);
+
+	describe('path not exist', () => {
+		expect(GQL_OUTPUT_FOLDER).to.not.be.a.path();
+	})
+
+	describe('invalid params', () => {
+
+		test('gql schema is null', () => {
+			const result = GraphQL2REST.generateGqlQueryFiles(null);
+
+			expect(result).to.equal(false);
+		});
+
+		test('gql schema is undefined', () => {
+			const result = GraphQL2REST.generateGqlQueryFiles(undefined);
+
+			expect(result).to.equal(false);
+		});
+
+		test('gql schema is empty object', () => {
+			const result = GraphQL2REST.generateGqlQueryFiles({});
+
+			expect(result).to.equal(false);
+		});
+
+		test('gql schema is empty array', () => {
+			const result = GraphQL2REST.generateGqlQueryFiles([]);
+
+			expect(result).to.equal(false);
+		});
+
+		test('destination param is empty', () => {
+			const result = GraphQL2REST.generateGqlQueryFiles(schema, '');
+
+			expect(result).to.equal(false);
+		});
+
+		test('destination param is undefined', () => {
+			const result = GraphQL2REST.generateGqlQueryFiles(schema, undefined, undefined, loggerMock);
+
+			expect(result).to.equal(false);
+		});
+
+		test('destination param is null', () => {
+			const result = GraphQL2REST.generateGqlQueryFiles(schema, null, undefined, loggerMock);
+
+			expect(result).to.equal(false);
+		});
+
+		test('depth limit is null', () => {
+			const result = GraphQL2REST.generateGqlQueryFiles(schema, GQL_OUTPUT_FOLDER, null);
+
+			expect(result).to.equal(false);
+		});
+
+		test('depth limit is negative', () => {
+			const result = GraphQL2REST.generateGqlQueryFiles(schema, GQL_OUTPUT_FOLDER, -100);
+
+			expect(result).to.equal(false);
+		});
+
+		test('depth limit is empty string', () => {
+			const result = GraphQL2REST.generateGqlQueryFiles(schema, GQL_OUTPUT_FOLDER, '');
+
+			expect(result).to.equal(false);
+		});
+	})
+
+	describe('generate gql query files', () => {
+		before(() => prepareEnv(schema));
+
+		after(() => clearEnv(GQL_OUTPUT_FOLDER));
+
+		test('should generate successfully', () => {
+			const result = GraphQL2REST.generateGqlQueryFiles(schema, GQL_OUTPUT_FOLDER, undefined, loggerMock);
+
+			expect(result).to.equal(true);
+		});
+
+		test('should create path', () => {
+			expect(GQL_OUTPUT_FOLDER).to.be.a.path();
+		});
+
+		test('should create directory', () => {
+			expect(GQL_OUTPUT_FOLDER).to.be.a.directory();
+		});
+
+		test('should create sub directories', () => {
+			expect(GQL_OUTPUT_FOLDER).to.be.a.directory().with.subDirs(['queries', 'mutations']);
+		});
+
+		test('should create index.js inside queries folder', () => {
+			expect(`${GQL_OUTPUT_FOLDER}/queries/index.js`).to.be.a.file();
+		});
+
+		test('should create index.js inside mutations folder', () => {
+			expect(`${GQL_OUTPUT_FOLDER}/mutations/index.js`).to.be.a.file();
+		});
+
+		test('sanity validation of generated queries', () => {
+			GraphQL2REST.generateGqlQueryFiles(buildSchema(schemaFileAdvanced.schema), GQL_OUTPUT_FOLDER_ADVANCED_TESTS, undefined, loggerMock);
+
+			const queries = require(GQL_OUTPUT_FOLDER_ADVANCED_TESTS);
+
+			expect(queries.mutations.signin.indexOf('signin')).to.not.equal(-1);
+		});
+	})
+
+});
+
+const prepareEnv = (schema) => {
+	clearEnv();
+	GraphQL2REST.generateGqlQueryFiles(schema,
+		GQL_OUTPUT_FOLDER, undefined, loggerMock);
+}
+
+const clearEnv = () => {
+	del.sync(GQL_OUTPUT_FOLDER);
+	del.sync(GQL_OUTPUT_FOLDER_ADVANCED_TESTS);
+	clearLastConsolePrint();
+	clearBuffer();
+	loggerMock.supressDebugLevel = false;
+}
+
+

--- a/test/unit/generateGqlQueryFiles.test.js
+++ b/test/unit/generateGqlQueryFiles.test.js
@@ -4,16 +4,13 @@ const chai = require('chai');
 const chaifs = require('chai-fs');
 const { expect } = chai;
 const {	buildSchema } = require('graphql');
-const del = require('del');
 
 const schemaFile = require('../test-fixtures/schemas/basic-graphql-schema-1');
 const schemaFileAdvanced = require('../test-fixtures/schemas/advanced-graphql-schema');
 const GraphQL2REST = require('../../src/index');
-const {
-	loggerMock,
-	clearBuffer,
-	clearLastConsolePrint,
-} = require('../mocks/logger');
+const { loggerMock } = require('../mocks/logger');
+
+const { clearEnv } = require('../testUtils');
 const GQL_OUTPUT_FOLDER = path.resolve(__dirname, '../test-outputs/gqloutput');
 const GQL_OUTPUT_FOLDER_ADVANCED_TESTS = path.resolve(__dirname, '../test-outputs/gqloutput_advanced');
 
@@ -93,7 +90,7 @@ describe('generateGqlQueryFiles:', () => {
 	describe('generate gql query files', () => {
 		before(() => prepareEnv(schema));
 
-		after(() => clearEnv(GQL_OUTPUT_FOLDER));
+		after(() => clearEnv([GQL_OUTPUT_FOLDER, GQL_OUTPUT_FOLDER_ADVANCED_TESTS]));
 
 		test('should generate successfully', () => {
 			const result = GraphQL2REST.generateGqlQueryFiles(schema, GQL_OUTPUT_FOLDER, undefined, loggerMock);
@@ -133,17 +130,9 @@ describe('generateGqlQueryFiles:', () => {
 });
 
 const prepareEnv = (schema) => {
-	clearEnv();
+	clearEnv([GQL_OUTPUT_FOLDER, GQL_OUTPUT_FOLDER_ADVANCED_TESTS]);
 	GraphQL2REST.generateGqlQueryFiles(schema,
 		GQL_OUTPUT_FOLDER, undefined, loggerMock);
-}
-
-const clearEnv = () => {
-	del.sync(GQL_OUTPUT_FOLDER);
-	del.sync(GQL_OUTPUT_FOLDER_ADVANCED_TESTS);
-	clearLastConsolePrint();
-	clearBuffer();
-	loggerMock.supressDebugLevel = false;
 }
 
 

--- a/test/unit/graphql2restTests.test.js
+++ b/test/unit/graphql2restTests.test.js
@@ -22,7 +22,7 @@ const { clearEnv, getOptions } = require('../testUtils')
 chai.use(chaifs);
 
 const prepareEnv = (schema, restRouter) => {
-	clearEnv(GQL_OUTPUT_FOLDER);
+	clearEnv([GQL_OUTPUT_FOLDER]);
 	rmwareHttpMock(restRouter);
 }
 
@@ -39,13 +39,14 @@ describe('GraphQL2REST router - forwards requests to underlying GraphQL layer an
 	after(() => {
 		responseBody = null;
 		statusCode = 0;
-		clearEnv(GQL_OUTPUT_FOLDER);
+		clearEnv([GQL_OUTPUT_FOLDER]);
 	});
 
 	describe('GET', () => {
 		describe('/testApp/v1/api/tweets/10 - successful GET call without body: ', () => {
 
 			before((done) => {
+				loggerMock.supressDebugLevel = true;
 				clearBuffer();
 				restRouter.runMiddleware('/testApp/v1/api/tweets/10', {
 					method: 'get'

--- a/test/unit/graphql2restTests.test.js
+++ b/test/unit/graphql2restTests.test.js
@@ -1,233 +1,52 @@
 const path = require('path');
-const {	test } = require('mocha');
+const {test} = require('mocha');
 const chai = require('chai');
 const chaifs = require('chai-fs');
-
-const { expect } = chai;
-
-const express = require('express');
 const rmwareHttpMock = require('run-middleware');
-const {	buildSchema } = require('graphql');
+const {buildSchema} = require('graphql');
 
-const del = require('del');
 const schemaFile = require('../test-fixtures/schemas/basic-graphql-schema-1');
-const schemaFileAdvanced = require('../test-fixtures/schemas/advanced-graphql-schema');
 const GraphQL2REST = require('../../src/index');
+const {expect} = chai;
 
 const {
 	loggerMock,
 	clearBuffer,
-	getLastConsolePrint,
-	clearLastConsolePrint,
-	getConsoleBuffer,
 } = require('../mocks/logger');
 
-const { execute } = require('../mocks/graphql');
+const {execute} = require('../mocks/graphql');
 
-// warning: these temp folders will be deleted entirely:
 const GQL_OUTPUT_FOLDER = path.resolve(__dirname, '../test-outputs/gqloutput');
-const GQL_OUTPUT_FOLDER_ADVANCED_TESTS = path.resolve(__dirname, '../test-outputs/gqloutput_advanced');
+const { clearEnv, getOptions } = require('../testUtils')
 
 chai.use(chaifs);
 
+const prepareEnv = (schema, restRouter) => {
+	clearEnv(GQL_OUTPUT_FOLDER);
+	rmwareHttpMock(restRouter);
+}
 
-/** * GenerateGqlQueryFiles Tests ***/
+describe('GraphQL2REST router - forwards requests to underlying GraphQL layer and correctly processes responses', () => {
+	const schema = buildSchema(schemaFile.schema);
+	GraphQL2REST.generateGqlQueryFiles(schema,
+		GQL_OUTPUT_FOLDER, undefined, loggerMock);
+	let restRouter = GraphQL2REST.init(schema, execute, getOptions(GQL_OUTPUT_FOLDER));
+	let responseBody = null;
+	let statusCode = 0;
 
-describe('generateGqlQueryFiles basic file creation tests:', () => {
-	let schema;
-	const g = GraphQL2REST;
-	const outputPath = GQL_OUTPUT_FOLDER;
-
-	before(() => {
-		schema = buildSchema(schemaFile.schema);
-		del.sync(outputPath);
-		expect(outputPath).to.not.be.a.path();
-		clearLastConsolePrint();
-		clearBuffer();
-	});
-
-	after(() => {
-		del.sync(outputPath);
-		clearBuffer();
-	});
-
-	test('successfully reads basic graphql schema and returns true', () => {
-		const result = g.generateGqlQueryFiles(schema, outputPath, undefined, loggerMock);
-		expect(result).to.equal(true);
-	});
-
-	test('displays or logs a success message', () => {
-		expect(getLastConsolePrint().toLowerCase()).to.include('successfully created');
-	});
-
-	test('creates gql folder with queries and mutations subdirs', () => {
-		expect(outputPath).to.be.a.path();
-		expect(outputPath).to.be.a.directory();
-		expect(outputPath).to.be.a.directory().with.subDirs(['queries', 'mutations']);
-	});
-
-	test('index.js is created inside queries folder', () => {
-		expect(`${outputPath}/queries/index.js`).to.be.a.file();
-	});
-
-	test('index.js is created inside mutations folder', () => {
-		expect(`${outputPath}/mutations/index.js`).to.be.a.file();
-	});
-});
-
-
-describe('generateGqlQueryFiles advanced schema parsing validation:', () => {
-	let schema;
-	const g = GraphQL2REST;
-	const outputPath = GQL_OUTPUT_FOLDER_ADVANCED_TESTS;
-
-	before(() => {
-		schema = buildSchema(schemaFileAdvanced.schema);
-		del.sync(outputPath);
-		clearLastConsolePrint();
-		clearBuffer();
-	});
+	before(() => prepareEnv(schema, restRouter));
 
 	after(() => {
-		del.sync(outputPath);
-		clearBuffer();
+		responseBody = null;
+		statusCode = 0;
+		clearEnv(GQL_OUTPUT_FOLDER);
 	});
 
-	test('sanity validation of generated queries', () => {
-		const result = g.generateGqlQueryFiles(schema, outputPath, undefined, loggerMock);
-		expect(result).to.equal(true);
-		const queries = require(outputPath);
-		expect(queries.mutations.signin.indexOf('signin')).to.not.equal(-1);
-	});
-
-	test('limit depth', () => {
-		/* TODO: investigate depth issue; currently rarely used. */
-		/* const result = g.generateGqlQueryFiles(schema, outputPath, 1, loggerMock);
-		expect(result).to.equal(true);
-		const queries = require(outputPath);
-		expect(queries.mutations.signup.indexOf('createdAt')).to.equal(-1); */
-	});
-});
-
-
-describe('generateGqlQueryFiles negative and error inducing tests:', () => {
-	let schema;
-	const g = GraphQL2REST;
-	const outputPath = GQL_OUTPUT_FOLDER_ADVANCED_TESTS;
-
-	before(() => {
-		schema = buildSchema(schemaFileAdvanced.schema);
-	});
-
-	after(() => {
-		clearBuffer();
-	});
-
-	test('invoking with empty schema returns false', () => {
-		const result = g.generateGqlQueryFiles({}, outputPath, undefined, loggerMock);
-		expect(result).to.equal(false);
-	});
-
-	test('invoking without a destination folder returns false', () => {
-		const result = g.generateGqlQueryFiles(schema, undefined, undefined, loggerMock);
-		expect(result).to.equal(false);
-	});
-});
-
-
-/** * GraphQL2REST Router Tests ***/
-
-describe('GraphQL2REST router tests:', () => {
-	let restRouter;
-	const outputPath = GQL_OUTPUT_FOLDER;
-
-	describe('init() router basic positive tests', () => {
-		let schema;
-		const g = GraphQL2REST;
-		const options = {
-			logger: loggerMock,
-			gqlGeneratorOutputFolder: outputPath,
-			manifestFile: '../test/test-fixtures/manifests/basicManifest1.json',
-			apiPrefix: '/testApp/v1',
-			middlewaresFile: '../test/test-fixtures/middleware/request-middleware.js'
-		};
-
-		before(() => {
-			schema = buildSchema(schemaFile.schema);
-			del.sync(outputPath);
-			g.generateGqlQueryFiles(schema, outputPath, undefined, loggerMock);
-			clearLastConsolePrint();
-			clearBuffer();
-		});
-
-		after(() => {
-			clearBuffer();
-		});
-
-		test('init returns a non null value', () => {
-			restRouter = g.init(schema, execute, options);
-			expect(restRouter).to.not.equal(null);
-			expect(restRouter).to.not.equal(undefined);
-		});
-
-		test('init returns an instance of Express router', () => {
-			expect(Object.getPrototypeOf(restRouter)).to.equal(express.Router);
-		});
-
-		test('route for GET operation is created (logged appropriately)', () => {
-			expect(getConsoleBuffer().toLowerCase()).to.include('Adding endpoint GET /testApp/v1/api/tweets/:id'.toLowerCase());
-		});
-
-		test('route for DELETE operation is created (logged appropriately)', () => {
-			expect(getConsoleBuffer().toLowerCase()).to.include('Adding endpoint DELETE /testApp/v1/api/tweets/:id'.toLowerCase());
-		});
-
-
-		test('route for POST operation is created (logged appropriately)', () => {
-			expect(getConsoleBuffer().toLowerCase()).to.include('Adding endpoint POST /testApp/v1/api/tweets'.toLowerCase());
-		});
-
-		test('route for additional GET operation is created (logged appropriately)', () => {
-			expect(getConsoleBuffer().toLowerCase()).to.include('Adding endpoint GET /testApp/v1/api/notifications'.toLowerCase());
-		});
-
-		test('route for PATCH operation is created (logged appropriately)', () => {
-			expect(getConsoleBuffer().toLowerCase()).to.include('Adding endpoint PATCH /testApp/v1/api/tweets/:id'.toLowerCase());
-		});
-
-		test('route for operation with invalid HTTP method in manifest is not created', () => {
-			expect(getConsoleBuffer().toLowerCase()).not.to.include('/api/bad-endpoint'.toLowerCase());
-		});
-
-		test('route for operation not in schema is not created (logged appropriately)', () => {
-			expect(getConsoleBuffer().toLowerCase()).to.include('nonExistentOperation is not found - cannot add endpoint PATCH for /testApp/v1/api/no-endpoint-should-be-created-here. Skipping this route.'.toLowerCase());
-		});
-	});
-
-
-	describe('router forwards requests to underlying GraphQL layer and correctly processes responses:', () => {
-		before(() => {
-			clearLastConsolePrint();
-			clearBuffer();
-			loggerMock.supressDebugLevel = true;
-			expect(restRouter).to.not.equal(null);
-			expect(restRouter).to.not.equal(undefined);
-			expect(Object.getPrototypeOf(restRouter)).to.equal(express.Router);
-			rmwareHttpMock(restRouter);
-		});
-
-		after(() => {
-			clearBuffer();
-			loggerMock.supressDebugLevel = false;
-			del.sync(outputPath);
-		});
-
-		describe('testing GET /testApp/v1/api/tweets/10 - successful GET call without body: ', () => {
-			let responseBody = null;
-			let statusCode = 0;
-			clearBuffer();
+	describe('GET', () => {
+		describe('/testApp/v1/api/tweets/10 - successful GET call without body: ', () => {
 
 			before((done) => {
+				clearBuffer();
 				restRouter.runMiddleware('/testApp/v1/api/tweets/10', {
 					method: 'get'
 				}, (code, body) => {
@@ -237,11 +56,11 @@ describe('GraphQL2REST router tests:', () => {
 				});
 			});
 
-			test('responds on HTTP GET request with 200 OK status code', () => {
+			test('responds with 200 OK status code', () => {
 				expect(statusCode).to.equal(200);
 			});
 
-			test('response body is correct as expected', () => {
+			test('response body is correct', () => {
 				expect(responseBody).to.not.equal(null);
 				expect(responseBody).to.not.equal(undefined);
 				expect(responseBody.oid).to.equal('0123-45687');
@@ -249,9 +68,7 @@ describe('GraphQL2REST router tests:', () => {
 			});
 
 			test('REST parameters were passed correctly to GraphQL mock layer', () => {
-				expect(responseBody.vars).to.deep.equal({
-					id: '10'
-				});
+				expect(responseBody.vars).to.deep.equal({id: '10'});
 			});
 
 			test('GraphQL operation "Tweet()" was invoked', () => {
@@ -259,101 +76,7 @@ describe('GraphQL2REST router tests:', () => {
 			});
 		});
 
-
-		describe('testing POST /testApp/v1/api/tweets - successful POST call with body and params renaming: ', () => {
-			let responseBody = null;
-			let statusCode = 0;
-			clearBuffer();
-
-			before((done) => {
-				restRouter.runMiddleware('/testApp/v1/api/tweets', {
-					method: 'post',
-					body: {
-						text: 'My Tweet'
-					}
-				}, (code, body) => {
-					responseBody = body;
-					statusCode = code;
-					done();
-				});
-			});
-
-			test('error mapping: responds on HTTP POST request with 201 CREATED status code', () => {
-				expect(statusCode).to.equal(201);
-			});
-
-			test('response body is correct as expected', () => {
-				expect(responseBody).to.not.equal(null);
-				expect(responseBody).to.not.equal(undefined);
-				expect(responseBody.oid).to.equal('0123-45687');
-				expect(responseBody.active).to.equal(true);
-			});
-
-			test('REST parameters were passed correctly to GraphQL mock layer', () => {
-				expect(responseBody.vars).to.deep.equal({
-					text: 'My Tweet' // variables are not renamed; instead, GraphQL query param names are reassigned
-				});
-			});
-
-			test('GraphQL parameters are mapped and reassigned correctly', () => {
-				expect(responseBody.queryStrReceived.loc.source.body).to.include('createTweet(tweetBody: $text)'); // parameter reassignment
-			});
-
-			test('GraphQL operation "createTweet()" was invoked', () => {
-				expect(responseBody.queryStrReceived.definitions[0].name.value).to.equal('createTweet');
-			});
-		});
-
-		describe('testing POST /testApp/v1/api/tweets - successful POST call with body and params renaming: ', () => {
-			let responseBody = null;
-			let statusCode = 0;
-			clearBuffer();
-
-			before((done) => {
-				restRouter.runMiddleware('/testApp/v1/api/tweets', {
-					method: 'post',
-					body: {
-						text: 'My Tweet'
-					}
-				}, (code, body) => {
-					responseBody = body;
-					statusCode = code;
-					done();
-				});
-			});
-
-			test('error mapping: responds on HTTP POST request with 201 CREATED status code', () => {
-				expect(statusCode).to.equal(201);
-			});
-
-			test('response body is correct as expected', () => {
-				expect(responseBody).to.not.equal(null);
-				expect(responseBody).to.not.equal(undefined);
-				expect(responseBody.oid).to.equal('0123-45687');
-				expect(responseBody.active).to.equal(true);
-			});
-
-			test('REST parameters were passed correctly to GraphQL mock layer', () => {
-				expect(responseBody.vars).to.deep.equal({
-					text: 'My Tweet' // variables are not renamed; instead, GraphQL query param names are reassigned
-				});
-			});
-
-			test('GraphQL parameters are mapped and reassigned correctly', () => {
-				expect(responseBody.queryStrReceived.loc.source.body).to.include('createTweet(tweetBody: $text)'); // parameter reassignment
-			});
-
-			test('GraphQL operation "createTweet()" was invoked', () => {
-				expect(responseBody.queryStrReceived.definitions[0].name.value).to.equal('createTweet');
-			});
-		});
-
-
-		describe('testing GET /testApp/v1/api/users - successful GET call returning array of objects: ', () => {
-			let responseBody = null;
-			let statusCode = 0;
-			clearBuffer();
-
+		describe('/testApp/v1/api/users - successful GET call returning array of objects: ', () => {
 			before((done) => {
 				restRouter.runMiddleware('/testApp/v1/api/users', {
 					method: 'get',
@@ -367,11 +90,11 @@ describe('GraphQL2REST router tests:', () => {
 				});
 			});
 
-			test('responds on HTTP GET request with 200 OK status code', () => {
+			test('responds with 200 OK status code', () => {
 				expect(statusCode).to.equal(200);
 			});
 
-			test('response body is correct as expected', () => {
+			test('response body is correct', () => {
 				expect(responseBody).to.not.equal(null);
 				expect(responseBody).to.not.equal(undefined);
 				expect(responseBody).to.deep.equal(
@@ -383,24 +106,20 @@ describe('GraphQL2REST router tests:', () => {
 							subObjId: 500
 						}
 					},
-					{
-						oid: '2',
-						title: 'The Best Result Ever #2',
-						elements: ['element1', 'element2'],
-						subObj: {
-							subObjId: 501
+						{
+							oid: '2',
+							title: 'The Best Result Ever #2',
+							elements: ['element1', 'element2'],
+							subObj: {
+								subObjId: 501
+							}
 						}
-					}
 					]
 				);
 			});
 		});
 
-		describe('testing GET /testApp/v1/api/users with field filtering - successful GET call returning array of objects with only specified fields: ', () => {
-			let responseBody = null; // TODO is this test redundant when using JMESPATH?
-			let statusCode = 0;
-			clearBuffer();
-
+		describe('/testApp/v1/api/users with field filtering - successful GET call returning array of objects with only specified fields: ', () => {
 			before((done) => {
 				restRouter.runMiddleware('/testApp/v1/api/users', {
 					method: 'get',
@@ -417,11 +136,11 @@ describe('GraphQL2REST router tests:', () => {
 				});
 			});
 
-			test('responds on HTTP GET request with 200 OK status code', () => {
+			test('responds with 200 OK status code', () => {
 				expect(statusCode).to.equal(200);
 			});
 
-			test('response body is correct as expected', () => {
+			test('response body is correct', () => {
 				expect(responseBody).to.not.equal(null);
 				expect(responseBody).to.not.equal(undefined);
 				console.dir(responseBody);
@@ -432,22 +151,18 @@ describe('GraphQL2REST router tests:', () => {
 							subObjId: 500
 						}
 					},
-					{
-						title: 'The Best Result Ever #2',
-						subObj: {
-							subObjId: 501
+						{
+							title: 'The Best Result Ever #2',
+							subObj: {
+								subObjId: 501
+							}
 						}
-					}
 					]
 				);
 			});
 		});
 
-		describe('testing GET /testApp/v1/api/users with JMESPath filter expression: ', () => {
-			let responseBody = null;
-			let statusCode = 0;
-			clearBuffer();
-
+		describe('/testApp/v1/api/users with JMESPath filter expression: ', () => {
 			before((done) => {
 				restRouter.runMiddleware('/testApp/v1/api/users', {
 					method: 'get',
@@ -464,11 +179,11 @@ describe('GraphQL2REST router tests:', () => {
 				});
 			});
 
-			test('responds on HTTP GET request with 200 OK status code', () => {
+			test('responds with 200 OK status code', () => {
 				expect(statusCode).to.equal(200);
 			});
 
-			test('response body is correct as expected', () => {
+			test('response body is correct', () => {
 				expect(responseBody).to.not.equal(null);
 				expect(responseBody).to.not.equal(undefined);
 				expect(responseBody).to.deep.equal(
@@ -488,11 +203,7 @@ describe('GraphQL2REST router tests:', () => {
 			});
 		});
 
-		describe('testing GET /testApp/v1/api/users with JMESPath filter expression on an array, that results in null in JMESPath language returns empty array:  ', () => {
-			let responseBody = null;
-			let statusCode = 0;
-			clearBuffer();
-
+		describe('/testApp/v1/api/users with JMESPath filter expression on an array, that results in null in JMESPath language returns empty array:  ', () => {
 			before((done) => {
 				restRouter.runMiddleware('/testApp/v1/api/users', {
 					method: 'get',
@@ -509,23 +220,18 @@ describe('GraphQL2REST router tests:', () => {
 				});
 			});
 
-			test('responds on HTTP GET request with 200 OK status code', () => {
+			test('responds with 200 OK status code', () => {
 				expect(statusCode).to.equal(200);
 			});
 
-			test('response body is correct as expected', () => {
+			test('response body is correct', () => {
 				expect(responseBody).to.not.equal(null);
 				expect(responseBody).to.not.equal(undefined);
 				expect(responseBody).to.deep.equal([]);
 			});
 		});
 
-
-		describe('testing GET /testApp/v1/api/users with JMESPath filter expression on an object, that results in null in JMESPath language returns empty object:  ', () => {
-			let responseBody = null;
-			let statusCode = 0;
-			clearBuffer();
-
+		describe('/testApp/v1/api/users with JMESPath filter expression on an object, that results in null in JMESPath language returns empty object:  ', () => {
 			before((done) => {
 				restRouter.runMiddleware('/testApp/v1/api/users', {
 					method: 'get',
@@ -539,23 +245,18 @@ describe('GraphQL2REST router tests:', () => {
 				});
 			});
 
-			test('responds on HTTP GET request with 200 OK status code', () => {
+			test('responds with 200 OK status code', () => {
 				expect(statusCode).to.equal(200);
 			});
 
-			test('response body is correct as expected', () => {
+			test('response body is correct', () => {
 				expect(responseBody).to.not.equal(null);
 				expect(responseBody).to.not.equal(undefined);
 				expect(responseBody).to.deep.equal({});
 			});
 		});
 
-
-		describe('testing GET /testApp/v1/api/users with invalid JMESPath filter expression fails gracefully with empty array:  ', () => {
-			let responseBody = null;
-			let statusCode = 0;
-			clearBuffer();
-
+		describe('/testApp/v1/api/users with invalid JMESPath filter expression fails gracefully with empty array:  ', () => {
 			before((done) => {
 				restRouter.runMiddleware('/testApp/v1/api/users', {
 					method: 'get',
@@ -572,22 +273,18 @@ describe('GraphQL2REST router tests:', () => {
 				});
 			});
 
-			test('responds on HTTP GET request with 200 OK status code', () => {
+			test('responds with 200 OK status code', () => {
 				expect(statusCode).to.equal(200);
 			});
 
-			test('response body is correct as expected', () => {
+			test('response body is correct', () => {
 				expect(responseBody).to.not.equal(null);
 				expect(responseBody).to.not.equal(undefined);
 				expect(responseBody).to.deep.equal([]);
 			});
 		});
 
-		describe('testing GET /api/notifications - successful GET call to test manifest condition fork (no query param "myquery", Notifications() should be invoked): ', () => {
-			let responseBody = null;
-			let statusCode = 0;
-			clearBuffer();
-
+		describe('/api/notifications - successful GET call to test manifest condition fork (no query param "myquery", Notifications() should be invoked): ', () => {
 			before((done) => {
 				restRouter.runMiddleware('/testApp/v1/api/notifications', {
 					method: 'get',
@@ -603,7 +300,7 @@ describe('GraphQL2REST router tests:', () => {
 				expect(statusCode).to.equal(200);
 			});
 
-			test('response body is correct as expected', () => {
+			test('response body is correct', () => {
 				expect(responseBody).to.not.equal(null);
 				expect(responseBody).to.not.equal(undefined);
 				expect(responseBody.oid).to.equal('0123-45687');
@@ -619,12 +316,7 @@ describe('GraphQL2REST router tests:', () => {
 			});
 		});
 
-
-		describe('testing GET /api/notifications - successful GET call to test manifest condition fork (WITH query param "myquery", NotificationsLegacy() should be invoked): ', () => {
-			let responseBody = null;
-			let statusCode = 0;
-			clearBuffer();
-
+		describe('/api/notifications - successful GET call to test manifest condition fork (WITH query param "myquery", NotificationsLegacy() should be invoked): ', () => {
 			before((done) => {
 				restRouter.runMiddleware('/testApp/v1/api/notifications', {
 					method: 'get',
@@ -643,7 +335,7 @@ describe('GraphQL2REST router tests:', () => {
 				expect(statusCode).to.equal(200);
 			});
 
-			test('response body is correct as expected', () => {
+			test('response body is correct', () => {
 				expect(responseBody).to.not.equal(null);
 				expect(responseBody).to.not.equal(undefined);
 				expect(responseBody.oid).to.equal('0123-45687');
@@ -661,13 +353,149 @@ describe('GraphQL2REST router tests:', () => {
 			});
 		});
 
+		describe('/api/notifications with "fields" filter; filter on SINGLE field (no query param "myquery", Notifications() should be invoked, response should have one field: ', () => {
+			before((done) => {
+				restRouter.runMiddleware('/testApp/v1/api/notifications', {
+					method: 'get',
+					query: {
+						fields: ' title  ' // whitespaces are on purpose, to test string being trimmed
+					},
+					body: {}
+				}, (code, body) => {
+					responseBody = body;
+					statusCode = code;
+					done();
+				});
+			});
 
-		// TODO refactor this test; refactor POST /api/notifications in manifest file (currently has redundant data)
-		describe('testing POST /api/notifications - conditional fork with request body wrapped ONCE only): ', () => {
-			let responseBody = null;
-			let statusCode = 0;
-			clearBuffer();
+			test('error mapping: responds on HTTP POST request with 200 OK', () => {
+				expect(statusCode).to.equal(200);
+			});
 
+			test('response body is correct as expected', () => {
+				expect(responseBody).to.not.equal(null);
+				expect(responseBody).to.not.equal(undefined);
+				expect(responseBody.oid).to.equal(undefined);
+				expect(responseBody).to.deep.equal({
+					title: 'The Best Result Ever'
+				});
+			});
+		});
+
+		describe('/api/notifications with "fields" filter; filter on MULTIPLE fields (no query param "myquery", Notifications() should be invoked, response should have two fields: ', () => {
+			before((done) => {
+				restRouter.runMiddleware('/testApp/v1/api/notifications', {
+					method: 'get',
+					query: {
+						fields: 'title , elements  ' // whitespaces are on purpose, to test string being trimmed
+					},
+					body: {}
+				}, (code, body) => {
+					responseBody = body;
+					statusCode = code;
+					done();
+				});
+			});
+
+			test('error mapping: responds on HTTP POST request with 200 OK', () => {
+				expect(statusCode).to.equal(200);
+			});
+
+			test('response body is correct as expected', () => {
+				expect(responseBody).to.not.equal(null);
+				expect(responseBody).to.not.equal(undefined);
+				expect(responseBody.oid).to.equal(undefined);
+				expect(responseBody).to.deep.equal({
+					title: 'The Best Result Ever',
+					elements: ['element1', 'element2']
+				});
+			});
+		});
+
+	})
+
+	describe('POST', () => {
+		describe('/testApp/v1/api/tweets - successful POST call with body and params renaming: ', () => {
+			before((done) => {
+				restRouter.runMiddleware('/testApp/v1/api/tweets', {
+					method: 'post',
+					body: {
+						text: 'My Tweet'
+					}
+				}, (code, body) => {
+					responseBody = body;
+					statusCode = code;
+					done();
+				});
+			});
+
+			test('error mapping: responds on HTTP POST request with 201 CREATED status code', () => {
+				expect(statusCode).to.equal(201);
+			});
+
+			test('response body is correct as expected', () => {
+				expect(responseBody).to.not.equal(null);
+				expect(responseBody).to.not.equal(undefined);
+				expect(responseBody.oid).to.equal('0123-45687');
+				expect(responseBody.active).to.equal(true);
+			});
+
+			test('REST parameters were passed correctly to GraphQL mock layer', () => {
+				expect(responseBody.vars).to.deep.equal({
+					text: 'My Tweet' // variables are not renamed; instead, GraphQL query param names are reassigned
+				});
+			});
+
+			test('GraphQL parameters are mapped and reassigned correctly', () => {
+				expect(responseBody.queryStrReceived.loc.source.body).to.include('createTweet(tweetBody: $text)'); // parameter reassignment
+			});
+
+			test('GraphQL operation "createTweet()" was invoked', () => {
+				expect(responseBody.queryStrReceived.definitions[0].name.value).to.equal('createTweet');
+			});
+		});
+
+		describe('/testApp/v1/api/tweets - successful POST call with body and params renaming: ', () => {
+			before((done) => {
+				restRouter.runMiddleware('/testApp/v1/api/tweets', {
+					method: 'post',
+					body: {
+						text: 'My Tweet'
+					}
+				}, (code, body) => {
+					responseBody = body;
+					statusCode = code;
+					done();
+				});
+			});
+
+			test('error mapping: responds on HTTP POST request with 201 CREATED status code', () => {
+				expect(statusCode).to.equal(201);
+			});
+
+			test('response body is correct as expected', () => {
+				expect(responseBody).to.not.equal(null);
+				expect(responseBody).to.not.equal(undefined);
+				expect(responseBody.oid).to.equal('0123-45687');
+				expect(responseBody.active).to.equal(true);
+			});
+
+			test('REST parameters were passed correctly to GraphQL mock layer', () => {
+				expect(responseBody.vars).to.deep.equal({
+					text: 'My Tweet' // variables are not renamed; instead, GraphQL query param names are reassigned
+				});
+			});
+
+			test('GraphQL parameters are mapped and reassigned correctly', () => {
+				expect(responseBody.queryStrReceived.loc.source.body).to.include('createTweet(tweetBody: $text)'); // parameter reassignment
+			});
+
+			test('GraphQL operation "createTweet()" was invoked', () => {
+				expect(responseBody.queryStrReceived.definitions[0].name.value).to.equal('createTweet');
+			});
+		});
+
+		describe('/api/notifications - conditional fork with request body wrapped ONCE only): ', () => {
 			before((done) => {
 				restRouter.runMiddleware('/testApp/v1/api/notifications', {
 					method: 'post',
@@ -695,7 +523,7 @@ describe('GraphQL2REST router tests:', () => {
 			});
 
 			test('request body was mutated correctly - wrapped ONCE with "{wrapper: data: {..} }', () => {
-				const { body } = responseBody.restRequest;
+				const {body} = responseBody.restRequest;
 				expect(body).to.deep.equal({
 					wrapper: {
 						data: {
@@ -711,12 +539,42 @@ describe('GraphQL2REST router tests:', () => {
 			});
 		});
 
+		describe('/testApp/v1/api/relationships/100/101 - request body should be wrapped in custom property when GraphQL receives it:', () => {
+			before((done) => {
+				restRouter.runMiddleware('/testApp/v1/api/relationships/100/10', {
+					method: 'post',
+					body: {
+						url: 'http://twitter/rels/100/101/',
+						relationshipDate: '1970-1-1'
+					}
+				}, (code, body) => {
+					responseBody = body;
+					done();
+				});
+			});
 
-		describe('testing PUT /api/tweets - parameters marked for deletion in the manifest using "__DELETE__" should not be passed to GraphQL: ', () => {
-			let responseBody = null;
-			let statusCode = 0;
-			clearBuffer();
+			test('request body is wrapped with "relationship" property before GraphQL receives it, as indicated in the manifest:', () => {
+				expect(responseBody).to.not.equal(null);
+				expect(responseBody).to.not.equal(undefined);
+				const {body} = responseBody.restRequest;
 
+				expect(body).to.deep.equal({
+					relationship: {
+						url: 'http://twitter/rels/100/101/',
+						relationshipDate: '1970-1-1'
+					}
+				});
+			});
+
+			test('path parameters are and passed as to GraphQL as expected:', () => {
+				expect(responseBody.queryStrReceived.definitions[0].variableDefinitions[0].variable.name.value).to.equal('first');
+				expect(responseBody.queryStrReceived.definitions[0].variableDefinitions[1].variable.name.value).to.equal('second');
+			});
+		});
+	})
+
+	describe('PUT', () => {
+		describe('/api/tweets - parameters marked for deletion in the manifest using "__DELETE__" should not be passed to GraphQL: ', () => {
 			before((done) => {
 				restRouter.runMiddleware('/testApp/v1/api/tweets', {
 					method: 'put',
@@ -740,12 +598,12 @@ describe('GraphQL2REST router tests:', () => {
 								objs: [{
 									kept: true,
 								},
-								{
-									kept: true,
-								},
-								{
-									alwaysKept: true
-								}
+									{
+										kept: true,
+									},
+									{
+										alwaysKept: true
+									}
 								],
 								nonArray: 100
 							},
@@ -795,12 +653,12 @@ describe('GraphQL2REST router tests:', () => {
 							objs: [{
 								kept: true,
 							},
-							{
-								kept: true,
-							},
-							{
-								alwaysKept: true
-							}
+								{
+									kept: true,
+								},
+								{
+									alwaysKept: true
+								}
 							],
 							nonArray: 100
 						},
@@ -815,12 +673,7 @@ describe('GraphQL2REST router tests:', () => {
 			});
 		});
 
-
-		describe('testing PUT /api/tweets - parameters marked for deletion do not affect result if they don\'t exist in payload', () => {
-			let responseBody = null;
-			let statusCode = 0;
-			clearBuffer();
-
+		describe('/api/tweets - parameters marked for deletion do not affect result if they don\'t exist in payload', () => {
 			before((done) => {
 				restRouter.runMiddleware('/testApp/v1/api/tweets', {
 					method: 'put',
@@ -840,12 +693,12 @@ describe('GraphQL2REST router tests:', () => {
 								objs: [{
 									kept: true,
 								},
-								{
-									kept: true,
-								},
-								{
-									alwaysKept: true
-								}
+									{
+										kept: true,
+									},
+									{
+										alwaysKept: true
+									}
 								],
 								nonArray: 100
 							},
@@ -893,12 +746,12 @@ describe('GraphQL2REST router tests:', () => {
 							objs: [{
 								kept: true,
 							},
-							{
-								kept: true,
-							},
-							{
-								alwaysKept: true
-							}
+								{
+									kept: true,
+								},
+								{
+									alwaysKept: true
+								}
 							],
 							nonArray: 100
 						},
@@ -912,81 +765,55 @@ describe('GraphQL2REST router tests:', () => {
 			});
 		});
 
-
-		describe('testing GET /api/notifications with "fields" filter; filter on SINGLE field (no query param "myquery", Notifications() should be invoked, response should have one field: ', () => {
-			let responseBody = null;
-			let statusCode = 0;
-			clearBuffer();
-
+		describe('/testApp/v1/api/relationships/100/101 - middleware function should be called and modify request object passed to GraphQL:', () => {
 			before((done) => {
-				restRouter.runMiddleware('/testApp/v1/api/notifications', {
-					method: 'get',
-					query: {
-						fields: ' title  ' // whitespaces are on purpose, to test string being trimmed
-					},
-					body: {}
+				restRouter.runMiddleware('/testApp/v1/api/relationships/100/10', {
+					method: 'put',
+					body: {
+						url: 'http://twitter/rels/100/101/',
+						relationshipDate: '1970-1-1'
+					}
 				}, (code, body) => {
 					responseBody = body;
-					statusCode = code;
 					done();
 				});
 			});
 
-			test('error mapping: responds on HTTP POST request with 200 OK', () => {
-				expect(statusCode).to.equal(200);
+			test('request body and route params are changed by the middleware function:', () => {
+				expect(responseBody).to.not.equal(null);
+				expect(responseBody).to.not.equal(undefined);
+				const {body, params} = responseBody.restRequest;
+
+				expect(body).to.deep.equal({
+					message: 'Touched by GraphQL2REST middleware!',
+					verb: 'PUT',
+					route: '/testApp/v1/api/relationships/:first/:second',
+					operation: 'updateTweetRelationship'
+				});
+
+				expect(params).to.deep.equal({
+					first: 'Touched by GraphQL2REST middleware!',
+					second: 'Touched by GraphQL2REST middleware!'
+				});
+			});
+
+			test('path parameters are and passed as to GraphQL as expected:', () => {
+				expect(responseBody.queryStrReceived.definitions[0].variableDefinitions[0].variable.name.value).to.equal('first');
+				expect(responseBody.queryStrReceived.definitions[0].variableDefinitions[1].variable.name.value).to.equal('second');
 			});
 
 			test('response body is correct as expected', () => {
 				expect(responseBody).to.not.equal(null);
 				expect(responseBody).to.not.equal(undefined);
-				expect(responseBody.oid).to.equal(undefined);
-				expect(responseBody).to.deep.equal({
-					title: 'The Best Result Ever'
-				});
+				expect(responseBody.oid).to.equal('0123-45687');
+				expect(responseBody.active).to.equal(true);
 			});
 		});
 
+	})
 
-		describe('testing GET /api/notifications with "fields" filter; filter on MULTIPLE fields (no query param "myquery", Notifications() should be invoked, response should have two fields: ', () => {
-			let responseBody = null;
-			let statusCode = 0;
-			clearBuffer();
-
-			before((done) => {
-				restRouter.runMiddleware('/testApp/v1/api/notifications', {
-					method: 'get',
-					query: {
-						fields: 'title , elements  ' // whitespaces are on purpose, to test string being trimmed
-					},
-					body: {}
-				}, (code, body) => {
-					responseBody = body;
-					statusCode = code;
-					done();
-				});
-			});
-
-			test('error mapping: responds on HTTP POST request with 200 OK', () => {
-				expect(statusCode).to.equal(200);
-			});
-
-			test('response body is correct as expected', () => {
-				expect(responseBody).to.not.equal(null);
-				expect(responseBody).to.not.equal(undefined);
-				expect(responseBody.oid).to.equal(undefined);
-				expect(responseBody).to.deep.equal({
-					title: 'The Best Result Ever',
-					elements: ['element1', 'element2']
-				});
-			});
-		});
-
-
-		describe('testing error handling: a DELETE request that should emit an error propagating from GraphQL to REST layer: ', () => {
-			let responseBody = null;
-			let statusCode = 0;
-			clearBuffer();
-
+	describe('DELETE', () => {
+		describe('request that should emit an error propagating from GraphQL to REST layer: ', () => {
 			before((done) => {
 				restRouter.runMiddleware('/testApp/v1/api/tweets/2010', {
 					method: 'delete',
@@ -1040,10 +867,7 @@ describe('GraphQL2REST router tests:', () => {
 			});
 		});
 
-		describe('testing error handling: a DELETE request on which GraphQL responds with BOTH error AND data should NOT emit an error, should return SUCCESS with data only: ', () => {
-			let responseBody = null;
-			let statusCode = 0;
-			clearBuffer();
+		describe('request on which GraphQL responds with BOTH error AND data should NOT emit an error, should return SUCCESS with data only: ', () => {
 			before((done) => {
 				restRouter.runMiddleware('/testApp/v1/api/tweets/2010', {
 					method: 'delete',
@@ -1080,11 +904,10 @@ describe('GraphQL2REST router tests:', () => {
 				expect(responseBody).not.to.have.property('errors');
 			});
 		});
+	})
 
-
-		describe('testing hide functionality: PATCH /testApp/v1/api/tweets/50 - hidden fields in manifest should be omitted from GraphQL response:', () => {
-			let responseBody = null;
-
+	describe('PATCH', () => {
+		describe('/testApp/v1/api/tweets/50 - hidden fields in manifest should be omitted from GraphQL response:', () => {
 			before((done) => {
 				restRouter.runMiddleware('/testApp/v1/api/tweets/50', {
 					method: 'patch',
@@ -1109,45 +932,7 @@ describe('GraphQL2REST router tests:', () => {
 			});
 		});
 
-		describe('testing wrapRequestBodyWith functionality: POST /testApp/v1/api/relationships/100/101 - request body should be wrapped in custom property when GraphQL receives it:', () => {
-			let responseBody = null;
-
-			before((done) => {
-				restRouter.runMiddleware('/testApp/v1/api/relationships/100/10', {
-					method: 'post',
-					body: {
-						url: 'http://twitter/rels/100/101/',
-						relationshipDate: '1970-1-1'
-					}
-				}, (code, body) => {
-					responseBody = body;
-					done();
-				});
-			});
-
-			test('request body is wrapped with "relationship" property before GraphQL receives it, as indicated in the manifest:', () => {
-				expect(responseBody).to.not.equal(null);
-				expect(responseBody).to.not.equal(undefined);
-				const { body } = responseBody.restRequest;
-
-				expect(body).to.deep.equal({
-					relationship: {
-						url: 'http://twitter/rels/100/101/',
-						relationshipDate: '1970-1-1'
-					}
-				});
-			});
-
-			test('path parameters are and passed as to GraphQL as expected:', () => {
-				expect(responseBody.queryStrReceived.definitions[0].variableDefinitions[0].variable.name.value).to.equal('first');
-				expect(responseBody.queryStrReceived.definitions[0].variableDefinitions[1].variable.name.value).to.equal('second');
-			});
-		});
-
-
-		describe('testing wrapRequestBodyWith functionality with multi-level wrapper object: PATCH /testApp/v1/api/relationships/100/101 - request body should be inside nested objected when GraphQL receives it:', () => {
-			let responseBody = null;
-
+		describe('/testApp/v1/api/relationships/100/101 - request body should be inside nested objected when GraphQL receives it:', () => {
 			before((done) => {
 				restRouter.runMiddleware('/testApp/v1/api/relationships/100/10', {
 					method: 'patch',
@@ -1164,7 +949,7 @@ describe('GraphQL2REST router tests:', () => {
 			test('request body is inside "{ updateData: { vars: { relationship: { ... } } } }" object before GraphQL receives it, as indicated in the manifest:', () => {
 				expect(responseBody).to.not.equal(null);
 				expect(responseBody).to.not.equal(undefined);
-				const { body } = responseBody.restRequest;
+				const {body} = responseBody.restRequest;
 				expect(body).to.deep.equal({
 					updateData: {
 						vars: {
@@ -1183,252 +968,5 @@ describe('GraphQL2REST router tests:', () => {
 			});
 		});
 
-
-		describe('testing GraphQL2REST request middleware function functionality: PUT /testApp/v1/api/relationships/100/101 - middleware function should be called and modify request object passed to GraphQL:', () => {
-			let responseBody = null;
-
-			before((done) => {
-				restRouter.runMiddleware('/testApp/v1/api/relationships/100/10', {
-					method: 'put',
-					body: {
-						url: 'http://twitter/rels/100/101/',
-						relationshipDate: '1970-1-1'
-					}
-				}, (code, body) => {
-					responseBody = body;
-					done();
-				});
-			});
-
-			test('request body and route params are changed by the middleware function:', () => {
-				expect(responseBody).to.not.equal(null);
-				expect(responseBody).to.not.equal(undefined);
-				const { body, params } = responseBody.restRequest;
-
-				expect(body).to.deep.equal({
-					message: 'Touched by GraphQL2REST middleware!',
-					verb: 'PUT',
-					route: '/testApp/v1/api/relationships/:first/:second',
-					operation: 'updateTweetRelationship'
-				});
-
-				expect(params).to.deep.equal({
-					first: 'Touched by GraphQL2REST middleware!',
-					second: 'Touched by GraphQL2REST middleware!'
-				});
-			});
-
-			test('path parameters are and passed as to GraphQL as expected:', () => {
-				expect(responseBody.queryStrReceived.definitions[0].variableDefinitions[0].variable.name.value).to.equal('first');
-				expect(responseBody.queryStrReceived.definitions[0].variableDefinitions[1].variable.name.value).to.equal('second');
-			});
-
-			test('response body is correct as expected', () => {
-				expect(responseBody).to.not.equal(null);
-				expect(responseBody).to.not.equal(undefined);
-				expect(responseBody.oid).to.equal('0123-45687');
-				expect(responseBody.active).to.equal(true);
-			});
-		});
-	});
-});
-
-
-describe('GraphQL2REST router optional custom parsing functions tests:', () => {
-	let restRouter;
-	const outputPath = GQL_OUTPUT_FOLDER;
-	let schema;
-	const g = GraphQL2REST;
-	const options = {
-		logger: loggerMock,
-		gqlGeneratorOutputFolder: outputPath,
-		manifestFile: '../test/test-fixtures/manifests/basicManifest1.json',
-		apiPrefix: '/testApp/v1'
-	};
-
-	const customFormatDataFn = (response) => {
-		if (!response || typeof response !== 'object') return 'error: response is not an object';
-		return {
-			title: response.data.title.toUpperCase(),
-			queryStrReceived: response.data.queryStrReceived,
-			vars: response.data.vars
-		};
-	};
-
-	const customFormatErrorFn = (response) => {
-		if (!response || typeof response !== 'object') return 'error: response is not an object';
-		return {
-			error: response.errors[0].message.toUpperCase()
-		};
-	};
-
-	before(() => {
-		schema = buildSchema(schemaFile.schema);
-		del.sync(outputPath);
-		g.generateGqlQueryFiles(schema, outputPath, undefined, loggerMock);
-		clearLastConsolePrint();
-		clearBuffer();
-		loggerMock.supressDebugLevel = true;
-	});
-
-	after(() => {
-		clearBuffer();
-		loggerMock.supressDebugLevel = false;
-		del.sync(outputPath);
-	});
-
-	test('init with custom parse function returns a non null value', () => {
-		restRouter = g.init(schema, execute, options, customFormatErrorFn, customFormatDataFn);
-		expect(restRouter).to.not.equal(null);
-		expect(restRouter).to.not.equal(undefined);
-	});
-
-
-	describe('testing GET /testApp/v1/api/tweets/10 - successful call should return customized response: ', () => {
-		let responseBody = null;
-		let statusCode = 0;
-		clearBuffer();
-
-		before((done) => {
-			restRouter.runMiddleware('/testApp/v1/api/tweets/10', {
-				method: 'get'
-			}, (code, body) => {
-				responseBody = body;
-				statusCode = code;
-				done();
-			});
-		});
-
-		test('responds on HTTP GET request with 200 OK status code', () => {
-			expect(statusCode).to.equal(200);
-		});
-
-		test('response body is customized as expected (only title in uppercase)', () => {
-			expect(responseBody).to.not.equal(null);
-			expect(responseBody).to.not.equal(undefined);
-			expect(responseBody.oid).to.not.equal('0123-45687');
-			expect(responseBody.title).to.equal('THE BEST RESULT EVER');
-		});
-
-		test('REST parameters were passed correctly to GraphQL mock layer', () => {
-			expect(responseBody.vars).to.deep.equal({
-				id: '10'
-			});
-		});
-
-		test('GraphQL operation "Tweet()" was invoked', () => {
-			expect(responseBody.queryStrReceived.definitions[0].name.value).to.equal('Tweet');
-		});
-	});
-
-	describe('testing DELETE /testApp/v1/api/tweets/2010, it should emit an error formatted according to custom function', () => {
-		let statusCode = 0;
-		let responseBody = null;
-
-		clearBuffer();
-
-		before((done) => {
-			restRouter.runMiddleware('/testApp/v1/api/tweets/2010', {
-				method: 'delete',
-				body: {
-					emitError: 4003,
-					isErrorWithData: false
-				},
-				query: {
-					myquery: 'names'
-				}
-			}, (code, body) => {
-				responseBody = body;
-				statusCode = code;
-				done();
-			});
-		});
-
-		test('error mapping: responds on HTTP POST request with 403 FORBIDDEN', () => {
-			expect(statusCode).to.equal(403);
-		});
-
-		test('response body is customized as expected (only error in uppercase)', () => {
-			expect(responseBody).to.not.equal(null);
-			expect(responseBody).to.not.equal(undefined);
-			expect(responseBody.oid).to.not.equal('0123-45687');
-			expect(responseBody.error).to.equal('UNAUTHORIZED');
-		});
-	});
-});
-
-
-describe('GraphQL2REST router negative and error inducing tests:', () => {
-	let restRouter;
-	const outputPath = GQL_OUTPUT_FOLDER;
-
-	describe('init() router basic negative tests', () => {
-		let schema;
-		const g = GraphQL2REST;
-		const options = {
-			logger: loggerMock,
-			gqlGeneratorOutputFolder: outputPath,
-			manifestFile: '../test/test-fixtures/manifests/basicManifest1.json',
-			apiPrefix: '/testApp/v1'
-		};
-
-		before(() => {
-			schema = buildSchema(schemaFile.schema);
-			del.sync(outputPath);
-			g.generateGqlQueryFiles(schema, outputPath, undefined, loggerMock);
-			clearLastConsolePrint();
-			clearBuffer();
-		});
-
-		after(() => {
-			clearBuffer();
-			del.sync(outputPath);
-			loggerMock.supressErrorLevel = false;
-		});
-
-
-		test('init with no execute function returns null and logs appropriate error', () => {
-			restRouter = g.init(schema, {}, options);
-			expect(restRouter).to.equal(null);
-			expect(getLastConsolePrint().toLowerCase()).to.include('The GraphQL execution function provided, executeFn, is not a function. Aborting.'.toLowerCase());
-		});
-
-		test('init with undefined schema function returns null and logs appropriate error', () => {
-			restRouter = g.init(undefined, execute, options);
-			expect(restRouter).to.equal(null);
-			expect(getLastConsolePrint().toLowerCase()).to.include('schema object is required but missing. Aborting'.toLowerCase());
-		});
-
-		test('init with missing manifest file returns null', () => {
-			loggerMock.supressErrorLevel = true;
-			restRouter = g.init(schema, execute, {
-				...options,
-				manifestFile: '../test/test-fixtures/manifests/_nonExistentManifest_.json'
-			});
-			expect(restRouter).to.equal(null);
-			loggerMock.supressErrorLevel = false;
-		});
-
-		test('init with missing gql generator output folder returns null', () => {
-			loggerMock.supressErrorLevel = true;
-			restRouter = g.init(schema, execute, {
-				...options,
-				gqlGeneratorOutputFolder: '../test/test-fixtures/_nonExistentFolder_'
-			});
-			expect(restRouter).to.equal(null);
-			loggerMock.supressErrorLevel = false;
-		});
-
-		test('optional params: init with formatDataError parameter which is not a function returns null and logs appropriate error message', () => {
-			restRouter = g.init(schema, execute, options, {});
-			expect(restRouter).to.equal(null);
-			expect(getLastConsolePrint().toLowerCase()).to.include('formatErrorFn function provided is not a function'.toLowerCase());
-		});
-
-		test('optional params: init with formatDataFn parameter which is not a function returns null and logs appropriate error message', () => {
-			restRouter = g.init(schema, execute, options, undefined, {});
-			expect(restRouter).to.equal(null);
-			expect(getLastConsolePrint().toLowerCase()).to.include('formatDataFn function provided is not a function'.toLowerCase());
-		});
-	});
+	})
 });

--- a/test/unit/init.test.js
+++ b/test/unit/init.test.js
@@ -32,7 +32,7 @@ describe('init router:', () => {
 
 	before(() => prepareEnv(schema, GQL_OUTPUT_FOLDER));
 
-	after(() => clearEnv(GQL_OUTPUT_FOLDER));
+	after(() => clearEnv([GQL_OUTPUT_FOLDER]));
 
 	describe('success create router', () => {
 		let restRouter;

--- a/test/unit/init.test.js
+++ b/test/unit/init.test.js
@@ -1,0 +1,161 @@
+const path = require('path');
+const {test} = require('mocha');
+const chai = require('chai');
+const chaifs = require('chai-fs');
+const {expect} = chai;
+const express = require('express');
+const {buildSchema} = require('graphql');
+
+const schemaFile = require('../test-fixtures/schemas/basic-graphql-schema-1');
+const GraphQL2REST = require('../../src/index');
+const {
+	loggerMock,
+	getLastConsolePrint,
+	getConsoleBuffer
+} = require('../mocks/logger');
+const {execute} = require('../mocks/graphql');
+const { clearEnv, prepareEnv } = require('../testUtils')
+
+const GQL_OUTPUT_FOLDER = path.resolve(__dirname, '../test-outputs/gqloutput');
+
+chai.use(chaifs);
+
+describe('init router:', () => {
+	const options = {
+		logger: loggerMock,
+		gqlGeneratorOutputFolder: GQL_OUTPUT_FOLDER,
+		manifestFile: '../test/test-fixtures/manifests/basicManifest1.json',
+		apiPrefix: '/testApp/v1',
+		middlewaresFile: '../test/test-fixtures/middleware/request-middleware.js'
+	};
+	const schema = buildSchema(schemaFile.schema);
+
+	before(() => prepareEnv(schema, GQL_OUTPUT_FOLDER));
+
+	after(() => clearEnv(GQL_OUTPUT_FOLDER));
+
+	describe('success create router', () => {
+		let restRouter;
+
+		test('init returns a non null value', () => {
+			restRouter = GraphQL2REST.init(schema, execute, options);
+
+			expect(restRouter).to.not.equal(null);
+			expect(restRouter).to.not.equal(undefined);
+		});
+
+		test('init returns an instance of Express router', () => {
+			expect(Object.getPrototypeOf(restRouter)).to.equal(express.Router);
+		});
+
+		test('route for GET operation is created (logged appropriately)', () => {
+			expect(getConsoleBuffer().toLowerCase()).to.include('Adding endpoint GET /testApp/v1/api/tweets/:id'.toLowerCase());
+		});
+
+		test('route for DELETE operation is created (logged appropriately)', () => {
+			expect(getConsoleBuffer().toLowerCase()).to.include('Adding endpoint DELETE /testApp/v1/api/tweets/:id'.toLowerCase());
+		});
+
+		test('route for POST operation is created (logged appropriately)', () => {
+			expect(getConsoleBuffer().toLowerCase()).to.include('Adding endpoint POST /testApp/v1/api/tweets'.toLowerCase());
+		});
+
+		test('route for additional GET operation is created (logged appropriately)', () => {
+			expect(getConsoleBuffer().toLowerCase()).to.include('Adding endpoint GET /testApp/v1/api/notifications'.toLowerCase());
+		});
+
+		test('route for PATCH operation is created (logged appropriately)', () => {
+			expect(getConsoleBuffer().toLowerCase()).to.include('Adding endpoint PATCH /testApp/v1/api/tweets/:id'.toLowerCase());
+		});
+
+		test('route for operation with invalid HTTP method in manifest is not created', () => {
+			expect(getConsoleBuffer().toLowerCase()).not.to.include('/api/bad-endpoint'.toLowerCase());
+		});
+
+		test('route for operation not in schema is not created (logged appropriately)', () => {
+			expect(getConsoleBuffer().toLowerCase()).to.include('nonExistentOperation is not found - cannot add endpoint PATCH for /testApp/v1/api/no-endpoint-should-be-created-here. Skipping this route.'.toLowerCase());
+		});
+	});
+
+	describe('optional params', () => {
+		const customFormatDataFn = (response) => {
+			if (!response || typeof response !== 'object') return 'error: response is not an object';
+			return {
+				title: response.data.title.toUpperCase(),
+				queryStrReceived: response.data.queryStrReceived,
+				vars: response.data.vars
+			};
+		};
+
+		const customFormatErrorFn = (response) => {
+			if (!response || typeof response !== 'object') return 'error: response is not an object';
+			return {
+				error: response.errors[0].message.toUpperCase()
+			};
+		};
+
+		test('init with custom parse function returns a non null value', () => {
+			const restRouter = GraphQL2REST.init(schema, execute, options, customFormatErrorFn, customFormatDataFn);
+
+			expect(Object.getPrototypeOf(restRouter)).to.equal(express.Router);
+		});
+
+	});
+
+	describe('invalid params', () => {
+		test('init with no execute function returns null and logs appropriate error', () => {
+			const restRouter = GraphQL2REST.init(schema, {}, options);
+
+			expect(restRouter).to.equal(null);
+
+			expect(getLastConsolePrint().toLowerCase()).to.include('The GraphQL execution function provided, executeFn, is not a function. Aborting.'.toLowerCase());
+		});
+
+		test('init with undefined schema function returns null and logs appropriate error', () => {
+			const restRouter = GraphQL2REST.init(undefined, execute, options);
+
+			expect(restRouter).to.equal(null);
+
+			expect(getLastConsolePrint().toLowerCase()).to.include('schema object is required but missing. Aborting'.toLowerCase());
+		});
+
+		test('init with missing manifest file returns null', () => {
+			const restRouter = GraphQL2REST.init(schema, execute, {
+				...options,
+				manifestFile: '../test/test-fixtures/manifests/_nonExistentManifest_.json'
+			});
+
+			expect(restRouter).to.equal(null);
+		});
+
+		test('init with missing gql generator output folder returns null', () => {
+			loggerMock.supressErrorLevel = true;
+			const restRouter = GraphQL2REST.init(schema, execute, {
+				...options,
+				gqlGeneratorOutputFolder: '../test/test-fixtures/_nonExistentFolder_'
+			});
+
+			expect(restRouter).to.equal(null);
+
+			loggerMock.supressErrorLevel = false;
+		});
+
+		test('optional params: init with formatDataError parameter which is not a function returns null and logs appropriate error message', () => {
+			const restRouter = GraphQL2REST.init(schema, execute, options, {});
+
+			expect(restRouter).to.equal(null);
+
+			expect(getLastConsolePrint().toLowerCase()).to.include('formatErrorFn function provided is not a function'.toLowerCase());
+		});
+
+		test('optional params: init with formatDataFn parameter which is not a function returns null and logs appropriate error message', () => {
+			const restRouter = GraphQL2REST.init(schema, execute, options, undefined, {});
+
+			expect(restRouter).to.equal(null);
+
+			expect(getLastConsolePrint().toLowerCase()).to.include('formatDataFn function provided is not a function'.toLowerCase());
+		});
+	});
+});
+
+

--- a/test/unit/logMessages.test.js
+++ b/test/unit/logMessages.test.js
@@ -20,7 +20,7 @@ chai.use(chaifs);
 describe('log messages:', () => {
 	const schema = buildSchema(schemaFile.schema);
 
-	after(() => clearEnv(GQL_OUTPUT_FOLDER));
+	after(() => clearEnv([GQL_OUTPUT_FOLDER]));
 
 	describe('generateGqlQueryFiles', () => {
 		describe('log errors', () => {
@@ -58,7 +58,7 @@ describe('log messages:', () => {
 
 		describe('log errors', () => {
 			before(() => {
-				clearEnv(GQL_OUTPUT_FOLDER);
+				clearEnv([GQL_OUTPUT_FOLDER]);
 				GraphQL2REST.generateGqlQueryFiles(schema, GQL_OUTPUT_FOLDER, 100, loggerMock);
 			});
 

--- a/test/unit/logMessages.test.js
+++ b/test/unit/logMessages.test.js
@@ -1,0 +1,78 @@
+const path = require('path');
+const {	test } = require('mocha');
+const chai = require('chai');
+const chaifs = require('chai-fs');
+const { expect } = chai;
+const {	buildSchema } = require('graphql');
+
+const schemaFile = require('../test-fixtures/schemas/basic-graphql-schema-1');
+const GraphQL2REST = require('../../src/index');
+const {
+	loggerMock,
+	getLastConsolePrint,
+} = require('../mocks/logger');
+const { execute } = require('../mocks/graphql');
+const GQL_OUTPUT_FOLDER = path.resolve(__dirname, '../test-outputs/gqloutput');
+const { noop, clearEnv, getOptions } = require('../testUtils')
+
+chai.use(chaifs);
+
+describe('log messages:', () => {
+	const schema = buildSchema(schemaFile.schema);
+
+	after(() => clearEnv(GQL_OUTPUT_FOLDER));
+
+	describe('generateGqlQueryFiles', () => {
+		describe('log errors', () => {
+			test('invalid gql schema param', () => {
+				GraphQL2REST.generateGqlQueryFiles(null, GQL_OUTPUT_FOLDER, 12,loggerMock);
+
+				expect(getLastConsolePrint().toLowerCase()).to.include('error: missing or empty graphqlschema object. aborting ');
+			});
+
+			test('invalid destination param', () => {
+				GraphQL2REST.generateGqlQueryFiles(schema, '' , 12, loggerMock);
+
+				expect(getLastConsolePrint().toLowerCase()).to.include('error: missing or invalid destination directory path (distdirpath). aborting ');
+			});
+
+			test('invalid depth limit param', () => {
+				GraphQL2REST.generateGqlQueryFiles(schema, GQL_OUTPUT_FOLDER, null, loggerMock);
+
+				expect(getLastConsolePrint().toLowerCase()).to.include('error: invalid depthlimitarg parameter. aborting ');
+			});
+		})
+
+		describe('log success', () => {
+			test('should generate successfully', () => {
+				GraphQL2REST.generateGqlQueryFiles(schema, GQL_OUTPUT_FOLDER, 100, loggerMock);
+
+				expect(getLastConsolePrint().toLowerCase()).to.include('info: [gqlgenerator] successfully created fully exploded graphql queries as gql files based on the schema. ');
+			});
+		})
+	})
+
+	describe('init', () => {
+		const formatErrorFn = noop;
+		const formatDataFn = noop;
+
+		describe('log errors', () => {
+			before(() => {
+				clearEnv(GQL_OUTPUT_FOLDER);
+				GraphQL2REST.generateGqlQueryFiles(schema, GQL_OUTPUT_FOLDER, 100, loggerMock);
+			});
+
+			test('schema obj is null', () => {
+				GraphQL2REST.init(null, execute, getOptions(GQL_OUTPUT_FOLDER), formatErrorFn, formatDataFn);
+
+				expect(getLastConsolePrint().toLowerCase()).to.include('error: init: schema object is required but missing. aborting initialization. ');
+			});
+
+			test('execute param is null', () => {
+				GraphQL2REST.init(schema, null, getOptions(GQL_OUTPUT_FOLDER));
+
+				expect(getLastConsolePrint().toLowerCase()).to.include('error: init: fatal: the graphql execution function provided, executefn, is not a function. aborting. ');
+			});
+		})
+	})
+});


### PR DESCRIPTION
refactor: separate tests by functionality to different files

add: validation to depthLimit params

add: validation to schemaObj to be instance of GraphQLSchema