### PR TITLE
Always return JSON responses

### DIFF
--- a/src/graphql2rest.js
+++ b/src/graphql2rest.js
@@ -386,7 +386,7 @@ const executeOperation = async ({ req, res, queryString, allParams, statusCode, 
 		response = funcs.formatErrorFn(response, statusCode);
 	}
 	debug(`Returning HTTP status code ${statusCode}`);
-	res.send(response);
+	res.json(response);
 };
 
 


### PR DESCRIPTION
When a GraphQL resolver that is hooked up to a REST endpoint returns `null`, `graphql2rest` returns a response with no body, and no `Content-Type` header.

The expected behavior in my opinion would be that the REST endpoint returns a JSON response containing the JSON `null`. By specifying `res.json` instead of `res.send`, the response will always contain a valid JSON response.