### PR TITLE
Add operation name to formatDataFn

### DIFF
--- a/src/graphql2rest.js
+++ b/src/graphql2rest.js
@@ -377,7 +377,7 @@ const executeOperation = async ({ req, res, queryString, allParams, statusCode, 
 	if (!Object.values(httpStatuses).includes(statusCode)) statusCode = consts.SUCCESS_STATUS_CODE;
 	res.status(statusCode);
 	if (!isErrorResponse) {
-		response = funcs.formatDataFn(response);
+		response = funcs.formatDataFn(response, operationName);
 		response = hideFields(response, hiddenFields);
 		response = filterResponse(response, req, config.filterFieldName);
 	} else {


### PR DESCRIPTION
We have a requirement to to do some response mapping, to take the varying schemas in our internal graph to a more cohesive format in our rest api. To accommodate this mapping we need some metadata (primarily the operationName) of the request. This PR adds the operationName to the call of the `formatDataFn`  that has been provided.

I did not see any relevant docs or tests to update, but if there are any, I am happy to do so. 